### PR TITLE
fix: multi-writer session corruption + web adapter (single-writer Feishu remote)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,6 +44,7 @@
 │  · dsh-sdk（官方 SDK client，默认）         │
 │  · dsh-acp（ACP 审批通道，可选）            │
 │  · dsh-headless（legacy fallback）          │
+│  · dsh-web（本地 dsh web agent，单写者）    │
 └──────────────────────────────────────────┘
         │
         ▼
@@ -81,7 +82,8 @@ DeepSeek Harness (dsh) ──▶ DeepSeek V4 Pro / Flash
 1. **飞书通道**：采用 `@larksuite/channel`（WebSocket 长连接 + PersonalAgent 应用），并开启 `resolveChatMode` 以区分普通群聊与话题 scope，免公网服务器、免域名、免内网穿透。
 2. **agent 后端解耦**：通过 adapter 接口抽象，`dsh` 为默认后端。默认走官方
    `@deepseek-ai/dsh-sdk-client`（`dsh-sdk-jsonrpc-server` runtime，原生 session + 流式事件）；
-   `DSH_LARK_ADAPTER=acp` 走官方 `@deepseek-ai/dsh-acp`（审批卡）；`headless` 保留 legacy fallback。
+   `DSH_LARK_ADAPTER=acp` 走官方 `@deepseek-ai/dsh-acp`（审批卡）；`headless` 保留 legacy fallback；
+   `DSH_LARK_ADAPTER=web` 走本地 dsh web agent（`session.prompt` + `/api/events.mux`，单写者，根治双写）。
    桥接核心只依赖 `AgentAdapter` / `AgentEvent` 契约，dsh 漂移只影响 `src/adapters/dsh/`。
 3. **工作区管理**：会话绑定 git worktree / 分支 + 项目级规则注入 + 上下文持久化，是本项目的核心差异化能力。
 4. **模型 / provider / 凭据管理**：`/model` `/providers` `/provider` `/key` 命令直接读写

--- a/src/adapters/dsh/web-adapter.ts
+++ b/src/adapters/dsh/web-adapter.ts
@@ -1,0 +1,344 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  AgentAdapter,
+  AgentAvailability,
+  AgentEvent,
+  AgentRun,
+  AgentRunOptions,
+} from '../types.js';
+import { EventChannel } from './event-channel.js';
+import { translateSessionEvent } from './sdk-translate.js';
+
+export interface WebAdapterOptions {
+  /** Base URL of the local dsh web agent (default http://127.0.0.1:3080). */
+  baseUrl?: string;
+  provider: string;
+  model: string;
+}
+
+/**
+ * Strip the history preamble the bridge run-flow prepends and send only the
+ * user's message: the web agent already resumes the full session itself, so
+ * the transcript must not be embedded a second time.
+ */
+function extractUserText(prompt: string): string {
+  const marker = 'Current user message:\n';
+  const idx = prompt.lastIndexOf(marker);
+  return idx === -1 ? prompt : prompt.slice(idx + marker.length);
+}
+
+function waitWithTimeout(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs > 0 ? timeoutMs : 5_000);
+    promise.then(
+      () => {
+        clearTimeout(timer);
+        resolve(true);
+      },
+      () => {
+        clearTimeout(timer);
+        resolve(true);
+      },
+    );
+  });
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+interface WebRunOptions {
+  sessionId: string | undefined;
+  prompt: string;
+  cwd: string | undefined;
+  model: string | undefined;
+  stopRequested: { value: boolean };
+}
+
+interface WebRunHandle {
+  events: AsyncIterable<AgentEvent>;
+  settled: Promise<void>;
+  stop: () => void;
+}
+
+function createWebRun(adapter: WebDshAdapter, options: WebRunOptions): WebRunHandle {
+  const channel = new EventChannel<AgentEvent>();
+  const tracker: { emitted: Set<string> } = { emitted: new Set() };
+  const stopRequested = options.stopRequested;
+  const turnEnded = deferred<void>();
+  const sessionReady = deferred<{
+    sessionId: string | undefined;
+    cwd: string | undefined;
+    model: string | undefined;
+  }>();
+  let hadError = false;
+  let ws: WebSocket | undefined;
+  let finished = false;
+
+  const finish = (): void => {
+    if (finished) return;
+    finished = true;
+    turnEnded.resolve();
+  };
+
+  const task = (async () => {
+    try {
+      // Resolve the target session (create a fresh one when the chat has none yet).
+      let sessionId = options.sessionId;
+      if (!sessionId) {
+        const created = (await adapter.rpc('session.create', { cwd: options.cwd })) as {
+          result?: {
+            ok: boolean;
+            value?: { sessionId?: string };
+            error?: { message?: string };
+          };
+        };
+        if (!created?.result?.ok) {
+          throw new Error(created?.result?.error?.message ?? 'web session.create failed');
+        }
+        sessionId = created.result.value?.sessionId;
+      }
+      if (sessionId === undefined) {
+        throw new Error('web session id unresolved');
+      }
+      sessionReady.resolve({ sessionId, cwd: options.cwd, model: options.model });
+
+      // Open the mux event stream (the web server broadcasts every session's
+      // events to every connection; filter by our session id).
+      ws = await adapter.openMux();
+      const onMessage = (event: { data: unknown }): void => {
+        let full: unknown;
+        try {
+          full = JSON.parse(String(event.data));
+        } catch {
+          return;
+        }
+        const frame = (full as { payload?: Record<string, unknown> })?.payload;
+        if (!frame || typeof frame.type !== 'string') return;
+        if (frame.type === 'session/event' && frame.sessionId === sessionId) {
+          for (const translated of translateSessionEvent(frame.event, tracker)) {
+            if (translated.type === 'error') hadError = true;
+            channel.push(translated);
+          }
+          const ev = frame.event as { type?: string; seq?: number };
+          if (ev?.type === 'turn/end') {
+            adapter.lastTurnEndSeq.set(sessionId, ev.seq ?? 0);
+            finish();
+          }
+        } else if (frame.type === 'stream/error') {
+          hadError = true;
+          channel.push({
+            type: 'error',
+            message:
+              (frame.error as { message?: string } | undefined)?.message ??
+              'web mux stream error',
+            terminationReason: 'failed',
+          });
+          finish();
+        }
+      };
+      ws.addEventListener('message', onMessage);
+      ws.addEventListener('close', () => finish(), { once: true });
+
+      // Send the user message; the web agent already holds the full history.
+      const promptResult = (await adapter.rpc('session.prompt', {
+        sessionId,
+        mode: 'queue',
+        content: [{ type: 'text', text: extractUserText(options.prompt) }],
+      })) as { result?: { ok: boolean; error?: { message?: string } } };
+      if (!promptResult?.result?.ok) {
+        throw new Error(promptResult?.result?.error?.message ?? 'web session.prompt failed');
+      }
+
+      // Wait for the turn to finish (or for stop).
+      await new Promise<void>((resolve) => {
+        void turnEnded.promise.then(() => resolve());
+        const timer = setInterval(() => {
+          if (stopRequested.value) {
+            clearInterval(timer);
+            resolve();
+          }
+        }, 250);
+        void turnEnded.promise.finally(() => clearInterval(timer));
+      });
+      ws.removeEventListener('message', onMessage);
+    } catch (error) {
+      sessionReady.resolve({
+        sessionId: options.sessionId,
+        cwd: options.cwd,
+        model: options.model,
+      });
+      if (!stopRequested.value) {
+        hadError = true;
+        channel.push({
+          type: 'error',
+          message: error instanceof Error ? error.message : String(error),
+          terminationReason: 'failed',
+        });
+      }
+    } finally {
+      finish();
+      try {
+        ws?.close();
+      } catch {
+        // ignore
+      }
+      channel.close();
+    }
+  })();
+
+  async function* events(): AsyncGenerator<AgentEvent> {
+    const info = await sessionReady.promise;
+    yield { type: 'system', sessionId: info.sessionId, cwd: info.cwd, model: info.model };
+    for await (const event of channel) yield event;
+    await task;
+    if (!hadError) {
+      yield {
+        type: 'done',
+        sessionId: info.sessionId,
+        terminationReason: stopRequested.value ? 'interrupted' : 'normal',
+      };
+    }
+  }
+
+  return {
+    events: events(),
+    settled: task.then(() => undefined),
+    stop: (): void => {
+      stopRequested.value = true;
+      finish();
+      try {
+        ws?.close();
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+/**
+ * `web` adapter: drive the local dsh web agent through its HTTP API
+ * (`session.create` / `session.prompt`) and its WebSocket event stream
+ * (`/api/events.mux`). The web agent is the single writer of every session
+ * log, which removes the multi-writer corruption (double-write) that any
+ * second agent runtime (SDK subprocess, guardian relaunch, stale live
+ * session) can cause, and gives cross-instance history continuation for free.
+ */
+export class WebDshAdapter implements AgentAdapter {
+  readonly id = 'dsh-web';
+  readonly displayName = 'DeepSeek Harness (Web GUI)';
+
+  /** Last turn/end seq handled per session by bridge runs (watcher dedupe). */
+  readonly lastTurnEndSeq = new Map<string, number>();
+
+  private readonly baseUrl: string;
+  private readonly model: string;
+  private readonly sockets = new Set<WebSocket>();
+  private disposed = false;
+
+  constructor(options: WebAdapterOptions) {
+    this.baseUrl = (options.baseUrl ?? 'http://127.0.0.1:3080').replace(/\/+$/, '');
+    this.model = options.model;
+  }
+
+  async rpc<T = unknown>(method: string, payload: unknown): Promise<T> {
+    const response = await fetch(`${this.baseUrl}/api/${method}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'client-request', rpcId: randomUUID(), method, payload }),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) throw new Error(`web RPC ${method} failed: HTTP ${response.status}`);
+    return response.json() as Promise<T>;
+  }
+
+  async openMux(): Promise<WebSocket> {
+    const url = `${this.baseUrl.replace(/^http/, 'ws')}/api/events.mux`;
+    const socket = new WebSocket(url);
+    this.sockets.add(socket);
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('web mux websocket open timed out')),
+        15_000,
+      );
+      socket.addEventListener(
+        'open',
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+      socket.addEventListener(
+        'error',
+        () => {
+          clearTimeout(timer);
+          reject(new Error('web mux websocket connection failed'));
+        },
+        { once: true },
+      );
+    });
+    return socket;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await this.checkAvailability()).ok;
+  }
+
+  async checkAvailability(): Promise<AgentAvailability> {
+    if (this.disposed) {
+      return { ok: false, error: 'adapter disposed', version: undefined };
+    }
+    try {
+      const response = await fetch(`${this.baseUrl}/`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(5_000),
+      });
+      return response.ok
+        ? { ok: true, error: undefined, version: `dsh-web@${this.baseUrl}` }
+        : { ok: false, error: `HTTP ${response.status}`, version: undefined };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+        version: undefined,
+      };
+    }
+  }
+
+  run(options: AgentRunOptions): AgentRun {
+    const cwd = options.cwd ?? process.cwd();
+    const handle = createWebRun(this, {
+      sessionId: options.sessionId,
+      prompt: options.prompt,
+      cwd,
+      model: options.model ?? this.model,
+      stopRequested: { value: false },
+    });
+    return {
+      runId: options.runId,
+      events: handle.events,
+      stop: async (): Promise<void> => {
+        handle.stop();
+        await handle.settled;
+      },
+      waitForExit: (timeoutMs: number) => waitWithTimeout(handle.settled, timeoutMs),
+    };
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    for (const socket of this.sockets) {
+      try {
+        socket.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.sockets.clear();
+  }
+}

--- a/src/adapters/dsh/web-watcher.ts
+++ b/src/adapters/dsh/web-watcher.ts
@@ -1,0 +1,253 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { zstdDecompressSync } from 'node:zlib';
+import type { ScopeDirectory } from '../../bridge/scope-directory.js';
+import type { StreamingChannel } from '../../bridge/types.js';
+import { log } from '../../core/logger.js';
+import type { SessionStore } from '../../session/store.js';
+import type { WorkspaceStore } from '../../workspace/store.js';
+
+/**
+ * Minimal surface of the web adapter used by the watcher (kept as an
+ * interface so the watcher does not import the concrete adapter class).
+ */
+export interface WebMuxProvider {
+  openMux(): Promise<WebSocket>;
+  lastTurnEndSeq: Map<string, number>;
+}
+
+export interface WebSessionWatcherInput {
+  adapter: WebMuxProvider;
+  channel: StreamingChannel;
+  sessions: SessionStore;
+  workspaces: WorkspaceStore;
+  scopeDirectory: ScopeDirectory;
+}
+
+export interface WebSessionWatcher {
+  close(): void;
+}
+
+interface TurnBuffer {
+  userText: string;
+  assistantText: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function textOf(parts: unknown): string {
+  if (!Array.isArray(parts)) return '';
+  return parts
+    .filter(isRecord)
+    .filter((p) => p.type === 'text' && typeof p.text === 'string')
+    .map((p) => p.text as string)
+    .join('');
+}
+
+/** Read the persisted session header (cwd) and title for push notifications. */
+async function readSessionMeta(sid: string): Promise<{ cwd: string; title: string }> {
+  const home = homedir();
+  const dshHome = process.env.DSH_HOME?.trim() || join(home, '.dsh');
+  const root = join(dshHome, 'sessions');
+  let found: string | undefined;
+  try {
+    const projects = await readdir(root, { withFileTypes: true });
+    for (const p of projects) {
+      if (!p.isDirectory()) continue;
+      const dir = join(root, p.name, sid);
+      try {
+        const entries = await readdir(dir, { withFileTypes: true });
+        for (const e of entries) {
+          if (e.isFile() && e.name.startsWith('session.jsonl')) {
+            found = join(dir, e.name);
+            break;
+          }
+        }
+      } catch {
+        // ignore
+      }
+      if (found !== undefined) break;
+    }
+  } catch {
+    // ignore
+  }
+  if (found === undefined) return { cwd: '', title: '' };
+  try {
+    const buf = await readFile(found);
+    const text = zstdDecompressSync(buf).toString('utf8');
+    let cwd = '';
+    let title = '';
+    for (const line of text.split('\n')) {
+      const t = line.trim();
+      if (!t) continue;
+      try {
+        const o = JSON.parse(t) as Record<string, unknown>;
+        if (o.type === 'session' && typeof o.cwd === 'string') cwd = o.cwd;
+        if (o.type === 'session/title') {
+          const data = isRecord(o.data) ? o.data : undefined;
+          if (typeof data?.title === 'string' && data.title.trim()) title = data.title.trim();
+        }
+      } catch {
+        // ignore
+      }
+    }
+    return { cwd, title };
+  } catch {
+    return { cwd: '', title: '' };
+  }
+}
+
+/**
+ * Push web-GUI turn completions to Feishu and auto-switch the chat's session
+ * mapping (and workspace cwd — `resumeFor` requires both to match) to the
+ * session that just completed, so the phone follows whatever session the web
+ * GUI is working on. Only web-initiated turns are pushed: turns handled by a
+ * bridge run are deduped via the adapter's `lastTurnEndSeq`.
+ */
+export function startWebSessionWatcher(input: WebSessionWatcherInput): WebSessionWatcher {
+  const { adapter, channel, sessions, workspaces, scopeDirectory } = input;
+  const buffers = new Map<string, TurnBuffer>();
+  let ws: WebSocket | undefined;
+  let closed = false;
+  let reconnectTimer: NodeJS.Timeout | undefined;
+
+  const sendToScopes = async (
+    sid: string,
+    meta: { cwd: string; title: string },
+    userText: string,
+    assistantText: string,
+  ): Promise<void> => {
+    const scopes = scopeDirectory.knownScopes();
+    for (const scope of scopes) {
+      const dest = scopeDirectory.resolve(scope);
+      if (!dest) continue;
+      try {
+        const current = sessions.getRaw(scope)?.sessionId;
+        if (current !== sid) {
+          sessions.set(scope, sid, meta.cwd);
+          if (meta.cwd) workspaces.setCwd(scope, meta.cwd);
+        }
+        sessions.recordExchange(scope, meta.cwd, userText ? [userText] : [], assistantText);
+        const head =
+          assistantText.length > 600 ? `${assistantText.slice(0, 600)}…` : assistantText;
+        const title = meta.title || sid.slice(0, 24);
+        await channel.sendMarkdown(
+          dest.chatId,
+          [
+            `📣 网页端会话「${title}」完成了一轮：`,
+            '',
+            head,
+            '',
+            '—— 飞书已自动进入该会话，继续发消息就在这个会话里干活。',
+          ].join('\n'),
+          dest.threadId ? { threadId: dest.threadId } : undefined,
+        );
+      } catch (error) {
+        log.fail('web-watch-send', error, { scope, sessionId: sid });
+      }
+    }
+  };
+
+  const connect = async (): Promise<void> => {
+    if (closed) return;
+    try {
+      ws = await adapter.openMux();
+      const onMessage = (event: { data: unknown }): void => {
+        let full: unknown;
+        try {
+          full = JSON.parse(String(event.data));
+        } catch {
+          return;
+        }
+        const frame = (full as { payload?: Record<string, unknown> })?.payload;
+        if (!frame || frame.type !== 'session/event' || typeof frame.sessionId !== 'string') return;
+        const sid = frame.sessionId;
+        const ev = isRecord(frame.event) ? frame.event : undefined;
+        if (ev === undefined || typeof ev.type !== 'string') return;
+        if (ev.type === 'turn/start') {
+          buffers.set(sid, { userText: '', assistantText: '' });
+        } else if (ev.type === 'user/message') {
+          const buf = buffers.get(sid);
+          if (!buf) return;
+          const data = isRecord(ev.data) ? ev.data : undefined;
+          const txt = textOf(data?.content);
+          if (
+            txt &&
+            !txt.startsWith('Current runtime context') &&
+            !txt.startsWith('<system-reminder>') &&
+            !txt.startsWith('background job')
+          ) {
+            buf.userText = txt;
+          }
+        } else if (ev.type === 'assistant/chunk') {
+          const buf = buffers.get(sid);
+          const data = isRecord(ev.data) ? ev.data : undefined;
+          const chunk = isRecord(data?.chunk) ? data.chunk : undefined;
+          if (
+            buf &&
+            chunk?.type === 'text-delta' &&
+            typeof chunk.text === 'string'
+          ) {
+            buf.assistantText += chunk.text;
+          }
+        } else if (ev.type === 'assistant/message') {
+          const buf = buffers.get(sid);
+          if (!buf) return;
+          const data = isRecord(ev.data) ? ev.data : undefined;
+          const msg = isRecord(data?.message) ? data.message : undefined;
+          const txt = textOf(msg?.content);
+          if (txt) buf.assistantText = txt;
+        } else if (ev.type === 'turn/end') {
+          const buf = buffers.get(sid);
+          buffers.delete(sid);
+          if (!buf) return;
+          const finalText = buf.assistantText.trim();
+          if (!finalText) return;
+          const seq = typeof ev.seq === 'number' ? ev.seq : 0;
+          // Small delay so a concurrent bridge run can record its handled turn
+          // first; without it the same turn could be pushed twice.
+          setTimeout(() => {
+            const handledSeq = adapter.lastTurnEndSeq.get(sid);
+            if (typeof handledSeq === 'number' && handledSeq >= seq) return;
+            void (async () => {
+              try {
+                const meta = await readSessionMeta(sid);
+                await sendToScopes(sid, meta, buf.userText, finalText);
+              } catch (error) {
+                log.fail('web-watch', error, { sessionId: sid });
+              }
+            })();
+          }, 300);
+        }
+      };
+      ws.addEventListener('message', onMessage);
+      ws.addEventListener(
+        'close',
+        () => {
+          if (!closed) reconnectTimer = setTimeout(connect, 5_000);
+        },
+        { once: true },
+      );
+    } catch (error) {
+      log.fail('web-watch', error);
+      if (!closed) reconnectTimer = setTimeout(connect, 10_000);
+    }
+  };
+
+  void connect();
+
+  return {
+    close: (): void => {
+      closed = true;
+      if (reconnectTimer !== undefined) clearTimeout(reconnectTimer);
+      try {
+        ws?.close();
+      } catch {
+        // ignore
+      }
+    },
+  };
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -3,6 +3,7 @@ import type { RuntimeEnv } from '../config/env.js';
 import { DshAdapter } from './dsh/adapter.js';
 import { SdkDshAdapter } from './dsh/sdk-adapter.js';
 import { ensureSdkProfile, resolveSdkLaunch } from './dsh/sdk-runtime.js';
+import { WebDshAdapter } from './dsh/web-adapter.js';
 import type { AgentAdapter } from './types.js';
 
 export interface AdapterPreferences {
@@ -15,6 +16,7 @@ export interface AdapterPreferences {
  * - `sdk` (default): official `@deepseek-ai/dsh-sdk-client` runtime.
  * - `acp`: official ACP server runtime with approval cards.
  * - `headless`: legacy subprocess fallback (kept for compatibility).
+ * - `web`: drive the local dsh web agent via its HTTP API (single writer).
  */
 export async function buildAgentAdapter(
   env: RuntimeEnv,
@@ -34,6 +36,13 @@ export async function buildAgentAdapter(
     case 'acp': {
       const { buildAcpAgentAdapter } = await import('./dsh/acp-adapter.js');
       return buildAcpAgentAdapter(env, preferences);
+    }
+    case 'web': {
+      return new WebDshAdapter({
+        baseUrl: env.webBaseUrl,
+        provider: env.provider,
+        model: preferences.model ?? env.model,
+      });
     }
     case 'sdk':
     default: {

--- a/src/bridge/run-flow.ts
+++ b/src/bridge/run-flow.ts
@@ -25,6 +25,7 @@ import type { GitWorktreeManager } from '../workspace/git-worktree.js';
 import type { StreamingChannel } from './types.js';
 import type { ApprovalOutcome, ApprovalRequest } from '../adapters/types.js';
 import type { QuestionCardInput } from '../card/question-card.js';
+import { archiveSessionDir, SESSION_BROKEN_RE, SESSION_CORRUPT_RE } from '../session/heal.js';
 
 export interface RunFlowInput {
   scope: string;
@@ -119,6 +120,37 @@ export async function runAgentBatch(input: RunFlowInput): Promise<void> {
           for await (const event of run.events) {
             if (timedOut) return;
             state = applyEvent(state, event, stopRequested);
+            // Self-heal: a broken-session error must not destroy the log. Only
+            // genuinely corrupt logs (seq gap / unparsable) are archived; the
+            // id-collision class just resets the chat mapping and keeps the
+            // persisted history recoverable.
+            if (
+              event.type === 'error' &&
+              event.terminationReason === 'failed' &&
+              SESSION_BROKEN_RE.test(event.message)
+            ) {
+              const brokenId = input.sessions.getRaw(input.scope)?.sessionId;
+              if (brokenId !== undefined) {
+                const corruptLog = SESSION_CORRUPT_RE.test(event.message);
+                if (corruptLog) {
+                  try {
+                    await archiveSessionDir(brokenId);
+                  } catch {
+                    // best effort
+                  }
+                }
+                input.sessions.clear(input.scope);
+                await input.channel.sendMarkdown(
+                  input.chatId,
+                  corruptLog
+                    ? '⚠️ 会话记录损坏，已自动归档并重置。请重新发送你的消息。'
+                    : '⚠️ 会话状态异常，已重置会话映射（历史日志保留，未删除）。请重新发送你的消息。',
+                  { ...replyOptions },
+                );
+                void run.stop();
+                return;
+              }
+            }
             if (event.type === 'final_text') {
               assistantOutput = event.content;
             } else if (event.type === 'text') {
@@ -198,8 +230,31 @@ export async function runAgentBatch(input: RunFlowInput): Promise<void> {
   } catch (error) {
     log.fail('run-flow', error, { scope: input.scope, runId });
     state = markInterrupted(state);
+    const runErrorText = errorMessage(error);
+    if (SESSION_BROKEN_RE.test(runErrorText)) {
+      const brokenSessionId = input.sessions.getRaw(input.scope)?.sessionId;
+      if (brokenSessionId !== undefined) {
+        const corruptLog = SESSION_CORRUPT_RE.test(runErrorText);
+        if (corruptLog) {
+          try {
+            await archiveSessionDir(brokenSessionId);
+          } catch {
+            // best effort
+          }
+        }
+        input.sessions.clear(input.scope);
+        await input.channel.sendMarkdown(
+          input.chatId,
+          corruptLog
+            ? '⚠️ 会话记录损坏，已自动归档并重置。请重新发送你的消息。'
+            : '⚠️ 会话状态异常，已重置会话映射（历史日志保留，未删除）。请重新发送你的消息。',
+          { ...replyOptions },
+        );
+        return;
+      }
+    }
     try {
-      await input.channel.sendMarkdown(input.chatId, `⚠️ agent 运行失败：${errorMessage(error)}`, {
+      await input.channel.sendMarkdown(input.chatId, `⚠️ agent 运行失败：${runErrorText}`, {
         ...replyOptions,
       });
     } catch {

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -18,6 +18,7 @@ import { adaptLarkChannel } from '../../bridge/lark-channel.js';
 import { runAgentBatch } from '../../bridge/run-flow.js';
 import { ScopeDirectory } from '../../bridge/scope-directory.js';
 import type { StreamingChannel } from '../../bridge/types.js';
+import { startWebSessionWatcher, type WebMuxProvider, type WebSessionWatcher } from '../../adapters/dsh/web-watcher.js';
 import { generateNotifyToken, NotifyServer } from '../../notify/server.js';
 import { buildAskHandler } from '../../notify/ask-handler.js';
 import type { StartOptions } from '../../cli.js';
@@ -323,6 +324,19 @@ export async function startBridgeEngine(
   const bridge = await startChannel(channelInput);
   streaming = adaptLarkChannel(bridge.channel);
   larkChannel = bridge.channel;
+  // In `web` adapter mode, watch web-GUI turn completions: push them to Feishu
+  // and auto-switch the chat's session mapping (single writer = web agent).
+  let webWatcher: WebSessionWatcher | undefined;
+  if (adapter.id === 'dsh-web' && env.webPush) {
+    webWatcher = startWebSessionWatcher({
+      adapter: adapter as unknown as WebMuxProvider,
+      channel: streaming,
+      sessions,
+      workspaces,
+      scopeDirectory,
+    });
+    log.info('cli', 'web-watcher-started', {});
+  }
   await notifyServer.start();
   process.env.DSH_LARK_NOTIFY_URL = notifyServer.url ?? '';
   process.env.DSH_LARK_ASK_URL = notifyServer.askUrl ?? '';
@@ -357,6 +371,7 @@ export async function startBridgeEngine(
     stop: async () => {
       if (stopped) return;
       stopped = true;
+      webWatcher?.close();
       heartbeat.stop();
       await notifyServer.stop();
       await bridge.disconnect();

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os';
 import { resolveDshRuntime } from './dsh-runtime.js';
 
 export type LarkTenant = 'feishu' | 'lark';
-export type AdapterMode = 'sdk' | 'acp' | 'headless';
+export type AdapterMode = 'sdk' | 'acp' | 'headless' | 'web';
 
 export interface RuntimeEnv {
   home: string;
@@ -16,6 +16,10 @@ export interface RuntimeEnv {
   /** True when DSH_LARK_DSH_COMMAND / DSH_LARK_DSH_ARGS were set explicitly. */
   dshExplicit: boolean;
   adapterMode: AdapterMode;
+  /** Base URL of the local dsh web agent used by the `web` adapter (default http://127.0.0.1:3080). */
+  webBaseUrl: string;
+  /** Push web-GUI turn completions to Feishu in `web` adapter mode (default true; DSH_LARK_WEB_PUSH=0 disables). */
+  webPush: boolean;
   provider: string;
   model: string;
   maxTokens: number | undefined;
@@ -112,8 +116,8 @@ function parseStopGrace(value: string | undefined): number {
 
 function parseAdapterMode(value: string | undefined): AdapterMode {
   const mode = nonEmpty(value) ?? 'sdk';
-  if (mode !== 'sdk' && mode !== 'acp' && mode !== 'headless') {
-    throw new Error(`DSH_LARK_ADAPTER must be "sdk", "acp" or "headless", got "${mode}"`);
+  if (mode !== 'sdk' && mode !== 'acp' && mode !== 'headless' && mode !== 'web') {
+    throw new Error(`DSH_LARK_ADAPTER must be "sdk", "acp", "headless" or "web", got "${mode}"`);
   }
   return mode;
 }
@@ -203,6 +207,8 @@ export function loadRuntimeEnv(
     dshArgs: dshRuntime.args,
     dshExplicit,
     adapterMode: parseAdapterMode(source.DSH_LARK_ADAPTER),
+    webBaseUrl: nonEmpty(source.DSH_LARK_WEB_URL) ?? 'http://127.0.0.1:3080',
+    webPush: parseBoolean(source.DSH_LARK_WEB_PUSH, true),
     provider: nonEmpty(source.DSH_LARK_PROVIDER) ?? DEFAULTS.provider,
     model: nonEmpty(source.DSH_LARK_MODEL) ?? DEFAULTS.model,
     maxTokens: parseMaxTokens(source.DSH_LARK_MAX_TOKENS),

--- a/src/guardian/service.ts
+++ b/src/guardian/service.ts
@@ -156,6 +156,7 @@ export class GuardianService {
   private safeAdapter: AgentAdapter | undefined;
   private readonly transcripts = new Map<string, TranscriptEntry[]>();
   private downStreak = 0;
+  private lastRelaunchAt: number | undefined;
   private lastHeartbeatFreshAt: number | undefined;
   private timer: NodeJS.Timeout | undefined;
   private ticking = false;
@@ -331,7 +332,36 @@ export class GuardianService {
       if (!this.state.profileSeenUp) return; // never observed up: stay silent
       this.downStreak += 1;
       if (this.downStreak < this.options.takeoverGracePolls) return;
-      await this.ensureChannel();
+      // Auto-relaunch the bridge so Feishu keeps working without a manual
+      // restart. The spawned process inherits this guardian's env, so run the
+      // guardian with DSH_LARK_ADAPTER=web and the bridge comes back in web
+      // mode (single writer). 60s cooldown prevents a spawn loop.
+      let relaunchedNow = false;
+      try {
+        const now = (this.options.now ?? Date.now)();
+        if (this.lastRelaunchAt === undefined || now - this.lastRelaunchAt > 60_000) {
+          const bin = this.dshBin;
+          if (bin && !processAlive) {
+            const spawn = this.options.spawnDetachedFn ?? spawnDetached;
+            const spawned: DetachedSpawn = spawn('node', [bin, '--profile', this.state.dshProfile]);
+            if (spawned.pid !== undefined) {
+              this.state.relaunchedPid = spawned.pid;
+              this.lastRelaunchAt = now;
+              relaunchedNow = true;
+              await this.save();
+              this.log().info('guardian', 'bridge-relaunched', {
+                pid: spawned.pid,
+                dshProfile: this.state.dshProfile,
+              });
+            }
+          }
+        }
+      } catch (error) {
+        this.log().fail('guardian', error);
+      }
+      // After a fresh relaunch, give the bridge time to come up before taking
+      // over the Feishu channel (avoids a brief double connection).
+      if (!relaunchedNow) await this.ensureChannel();
     } catch (error) {
       this.log().fail('guardian', error);
     } finally {

--- a/src/session/heal.ts
+++ b/src/session/heal.ts
@@ -1,0 +1,55 @@
+import { mkdir, readdir, rename } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Error classes that mean the persisted session does not match the live one
+ * (e.g. a second runtime resumed it, or a stale live session overlapped it).
+ * These are NOT log corruption: the log must be preserved so the conversation
+ * stays recoverable. Only a genuine `corrupt session log / seq gap` is
+ * archived (see {@link SESSION_CORRUPT_RE}).
+ */
+export const SESSION_BROKEN_RE =
+  /id collision|corrupt session log|already has a persisted log|does not match this live session/i;
+
+/** Errors that mean the log itself is unreadable/inconsistent. */
+export const SESSION_CORRUPT_RE = /corrupt session log|seq gap/i;
+
+/**
+ * Move a session directory out of `$DSH_HOME/sessions` into
+ * `~/.dsh-lark/_archived-sessions/<id>-<ts>` so the heal can reset the chat
+ * mapping without destroying the conversation history.
+ * @returns true when the directory was found and moved.
+ */
+export async function archiveSessionDir(sessionId: string): Promise<boolean> {
+  const home = homedir();
+  const dshHome = process.env.DSH_HOME?.trim() || join(home, '.dsh');
+  const root = join(dshHome, 'sessions');
+
+  const walk = async (dir: string): Promise<string | undefined> => {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return undefined;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === sessionId) return full;
+        const found = await walk(full);
+        if (found !== undefined) return found;
+      }
+    }
+    return undefined;
+  };
+
+  const found = await walk(root);
+  if (found === undefined) return false;
+
+  const larkHome = process.env.DSH_LARK_HOME?.trim() || join(home, '.dsh-lark');
+  const bakRoot = join(larkHome, '_archived-sessions');
+  await mkdir(bakRoot, { recursive: true });
+  await rename(found, join(bakRoot, `${sessionId}-${Date.now()}`));
+  return true;
+}


### PR DESCRIPTION
## Summary

Fixes the recurring **session-log corruption from multiple writers** and adds a **single-writer `web` adapter**: the Feishu bridge drives the **local dsh web agent** through its HTTP API (`session.create` / `session.prompt`) and WebSocket event stream (`/api/events.mux`) instead of spawning its own agent runtime, so only one process ever writes a session log. Also included: a self-heal fix (only archive genuinely corrupt logs) and a guardian auto-relaunch.

Closes #8 (the issue contains the full root-cause analysis and the dist-level diffs).

## Changes

**`feat(adapters)` — `web` adapter** (`src/adapters/dsh/web-adapter.ts`, `src/adapters/index.ts`, `src/config/env.ts`)
- New `DSH_LARK_ADAPTER=web` mode: input via `POST /api/session.prompt` on the local dsh web agent (default `http://127.0.0.1:3080`, `DSH_LARK_WEB_URL`), output via a WebSocket to `/api/events.mux` translated into the existing `AgentEvent` vocabulary.
- The web agent is the **single writer** of every session log → the multi-writer (double-write) corruption disappears, and cross-instance history continuation works for free (the web agent resumes persisted logs natively).
- New chats go through `session.create`; existing chats resume with full history.
- `DSH_LARK_WEB_PUSH=0` disables the push watcher.

**`fix(run-flow)` — self-heal v2** (`src/session/heal.ts`, `src/bridge/run-flow.ts`)
- The old heal treated every `id collision`-class error as a corrupt log and **moved the whole session directory away** (including healthy logs) → `ENOENT` cascades and unreachable conversations.
- Now only `/corrupt session log|seq gap/` archives the log; `id collision` / `already has a persisted log` / `does not match this live session` only reset the chat mapping and keep the persisted history recoverable.

**`feat(guardian)` — auto-relaunch** (`src/guardian/service.ts`)
- When the bridge is down, the guardian respawns it with the same env (run the guardian with `DSH_LARK_ADAPTER=web` so the bridge comes back in web mode), 60 s cooldown, and skips channel takeover right after a fresh relaunch to avoid a brief double connection.

**`feat(bridge)` — web session watcher** (`src/adapters/dsh/web-watcher.ts`, `src/cli/commands/run.ts`)
- In `web` mode, a persistent mux listener pushes **web-GUI-initiated** turn completions to Feishu and **auto-switches** the chat's session mapping **and the workspace cwd** (both must match for `resumeFor`) so the phone follows whatever session the web GUI is working on. Bridge-initiated turns are deduped via the adapter's `lastTurnEndSeq`.

## Verification

- `pnpm typecheck` ✅ · `pnpm build` ✅
- End-to-end on Windows: phone Feishu message → web-mode bridge → web agent executes (web-GUI persona, real PowerShell run) → reply streamed back to Feishu.
- Web-GUI completion → pushed to Feishu + mapping/cwd switched; the next Feishu message continued in that session (no new session created).
- Session logs validated with the official `SessionLogScanner` semantics; `session.history` loads every session.
- Test suite: the 13–15 pre-existing failures (Windows atomic-write `:memory:` paths, network probes) fail identically on the base branch; no test files were touched.

## Notes

- `DSH_LARK_ADAPTER=sdk` remains the default; rollback is a one-line env change.
- The related `@deepseek-ai/dsh-sdk-jsonrpc-server` resume patch (id-collision root fix on the dsh core) is described in #8; with the `web` adapter it is not needed.
- Docs updated: `docs/ARCHITECTURE.md` layering note for the adapter list in `src/adapters/index.ts` (kept minimal; happy to expand if wanted).
