### PR TITLE
feat(commands): add /newg to auto-create a group chat and start a fresh session

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Just send a normal message to the bot in Feishu to get started. Common commands:
 | 命令 Command | 作用 Description |
 | --- | --- |
 | `/new` `/reset` | 开始新会话<br>Start a new session |
+| `/newg <群名>` | 自动新建群聊（拉你入群）并开新会话，当前会话保留<br>Auto-create a group chat (with you invited) and start a fresh session there; the current session is untouched |
 | `/cd <path>` | 切换工作目录并重置会话<br>Change working directory and reset the session |
 | `/ws list` | 查看命名工作空间<br>List named workspaces |
 | `/ws save <name>` | 保存当前工作空间<br>Save the current workspace |
@@ -169,6 +170,10 @@ Just send a normal message to the bot in Feishu to get started. Common commands:
 飞书消息中的图片会下载到本地 media 目录并传给 dsh；文本类文件会读取内容并注入任务上下文。
 
 Images in Feishu messages are downloaded to the local media directory and passed to dsh; text files are read and their content is injected into the task context.
+
+**`/newg <群名>`**：通过飞书 API 自动新建一个私密群、把发送者拉入群，并回复群链接——在新群里发消息即为新 scope / 新会话，当前会话不受影响。需要应用具备 `im:chat` 与 `im:chat.members:write_only` 权限（在开发者后台「权限管理」申请）。
+
+**`/newg <group name>`**: auto-creates a private group via the Feishu API, invites the sender, and replies with a group link — chatting in the new group starts a fresh scope/session while the current session is untouched. Requires the `im:chat` and `im:chat.members:write_only` scopes (apply in the developer console).
 
 同一 scope（私聊 / 群聊 / 话题）默认允许 **2 个任务并行**（`DSH_LARK_SCOPE_CONCURRENCY` 或
 `/concurrency` 调整）：连续发来的多条消息会以独立 run 并行推进，每个 run 使用独立的 dsh

--- a/src/bridge/lark-channel.ts
+++ b/src/bridge/lark-channel.ts
@@ -38,6 +38,9 @@ export function adaptLarkChannel(channel: LarkChannel): StreamingChannel {
     async sendCard(chatId, card, options) {
       await channel.send(chatId, { card }, toLarkSendOptions(options));
     },
+    async createChat(opts) {
+      return channel.createChat(opts);
+    },
     async streamCard(chatId, initial, producer, options) {
       await channel.stream(
         chatId,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -35,6 +35,15 @@ export interface CommandChannel {
     options?: SendOptions,
   ): Promise<void>;
   sendCard?(chatId: string, card: object): Promise<void>;
+  /** Create a group chat and seed it with members (Feishu `im.v1.chat.create`). */
+  createChat?(opts: {
+    name: string;
+    description?: string;
+    inviteUserIds?: string[];
+    userIdType?: 'open_id' | 'user_id' | 'union_id';
+    chatMode?: 'group';
+    chatType?: 'private' | 'public';
+  }): Promise<{ chatId: string }>;
 }
 
 export interface CommandContext {
@@ -75,6 +84,7 @@ const HELP = [
   '**dsh-lark-bot 命令**',
   '',
   '- `/new` `/reset` — 开始新会话',
+  '- `/newg <群名>` — 自动新建群聊（拉你入群）并开新会话，当前会话保留',
   '- `/cd <path>` — 切换工作目录并重置会话',
   '- `/ws list|save <name>|use <name>|remove <name>` — 管理工作空间',
   '- `/status` — 查看当前状态',
@@ -115,6 +125,64 @@ async function handleNew(_args: string, ctx: CommandContext): Promise<void> {
     ctx,
     interrupted > 0 ? `已中断 ${String(interrupted)} 个任务并开始新会话。` : '已开始新会话。',
   );
+}
+
+const MAX_GROUP_NAME_LENGTH = 60;
+
+/** Open a chat via the Feishu applink (client-side deep link). */
+function groupAppLink(chatId: string): string {
+  return `https://applink.feishu.cn/client/chat/open?chatId=${encodeURIComponent(chatId)}`;
+}
+
+/**
+ * `/newg <群名>` — create a new group chat via the Feishu API, invite the
+ * requesting user, and reply with a link. Because each scope (chat) owns an
+ * independent session, chatting in the new group automatically starts a fresh
+ * session there while the current session stays untouched.
+ */
+async function handleNewGroup(args: string, ctx: CommandContext): Promise<void> {
+  const name = args.trim();
+  if (!name) {
+    await reply(ctx, '用法：`/newg <群名>` — 自动新建群聊并开始新会话');
+    return;
+  }
+  if (name.length > MAX_GROUP_NAME_LENGTH) {
+    await reply(
+      ctx,
+      `群名过长（上限 ${String(MAX_GROUP_NAME_LENGTH)} 字符，当前 ${String(name.length)}）。`,
+    );
+    return;
+  }
+  if (!ctx.channel.createChat) {
+    await reply(ctx, '当前渠道不支持自动建群。');
+    return;
+  }
+  if (!ctx.senderId) {
+    await reply(ctx, '无法识别发送者 open_id，不能自动建群。');
+    return;
+  }
+  try {
+    const { chatId } = await ctx.channel.createChat({
+      name,
+      chatType: 'private',
+      chatMode: 'group',
+      inviteUserIds: [ctx.senderId],
+      userIdType: 'open_id',
+    });
+    await reply(
+      ctx,
+      [
+        `✅ 已创建群聊：**${name}**`,
+        `- 群 ID：\`${chatId}\``,
+        `- 已将你加入群聊，新会话将在群里自动开始（当前会话不受影响）`,
+        '',
+        `👉 [打开群聊](${groupAppLink(chatId)})`,
+      ].join('\n'),
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await reply(ctx, `❌ 建群失败：\`${message}\``);
+  }
 }
 
 async function handleCd(args: string, ctx: CommandContext): Promise<void> {
@@ -433,6 +501,7 @@ async function handleHelp(_args: string, ctx: CommandContext): Promise<void> {
 const handlers: Record<string, Handler> = {
   '/new': handleNew,
   '/reset': handleNew,
+  '/newg': handleNewGroup,
   '/cd': handleCd,
   '/ws': handleWs,
   '/status': handleStatus,

--- a/test/commands/index.test.ts
+++ b/test/commands/index.test.ts
@@ -158,5 +158,69 @@ describe('command router', () => {
     expect(body).toContain('/provider');
     expect(body).toContain('/key');
     expect(body).toContain('/help');
+    expect(body).toContain('/newg');
+  });
+
+  it('/newg creates a group, invites the sender and replies with a link', async () => {
+    const createChat = vi.fn().mockResolvedValue({ chatId: 'oc_new_group' });
+    const ctx = makeContext({
+      senderId: 'ou_sender',
+      channel: {
+        sendMarkdown: vi.fn().mockResolvedValue(undefined),
+        createChat,
+      } as unknown as CommandChannel,
+    });
+
+    const handled = await tryHandleCommand('/newg 项目A', ctx);
+
+    expect(handled).toBe(true);
+    expect(createChat).toHaveBeenCalledWith({
+      name: '项目A',
+      chatType: 'private',
+      chatMode: 'group',
+      inviteUserIds: ['ou_sender'],
+      userIdType: 'open_id',
+    });
+    const body = (ctx.channel.sendMarkdown as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[1] as string;
+    expect(body).toContain('项目A');
+    expect(body).toContain('oc_new_group');
+    expect(body).toContain('applink.feishu.cn/client/chat/open?chatId=oc_new_group');
+  });
+
+  it('/newg without a name prints usage', async () => {
+    const ctx = makeContext();
+    await tryHandleCommand('/newg', ctx);
+
+    const body = (ctx.channel.sendMarkdown as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[1] as string;
+    expect(body).toContain('用法');
+    expect(ctx.channel.createChat).toBeUndefined();
+  });
+
+  it('/newg reports missing channel support', async () => {
+    const ctx = makeContext({ senderId: 'ou_sender' });
+    await tryHandleCommand('/newg 项目A', ctx);
+
+    const body = (ctx.channel.sendMarkdown as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[1] as string;
+    expect(body).toContain('不支持');
+  });
+
+  it('/newg surfaces create failures', async () => {
+    const ctx = makeContext({
+      senderId: 'ou_sender',
+      channel: {
+        sendMarkdown: vi.fn().mockResolvedValue(undefined),
+        createChat: vi.fn().mockRejectedValue(new Error('scope missing')),
+      } as unknown as CommandChannel,
+    });
+
+    await tryHandleCommand('/newg 项目A', ctx);
+
+    const body = (ctx.channel.sendMarkdown as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[1] as string;
+    expect(body).toContain('建群失败');
+    expect(body).toContain('scope missing');
   });
 });


### PR DESCRIPTION
## What

Adds a `/newg <群名>` command to dsh-lark-bot: it auto-creates a **private group chat** via the Feishu API, invites the requesting user, and replies with a group applink.

Since each scope (chat) owns an independent session, chatting in the new group automatically starts a fresh session there — the current session stays untouched.

## Why

Users want to "open another session while keeping the current one" with one command, without manually creating a group and adding the bot.

## Changes

- `src/commands/index.ts`
  - `CommandChannel` gains an optional `createChat()` capability
  - new `handleNewGroup` handler (`/newg <name>`), registered in the command table, listed in `/help`
  - guards: empty name → usage, >60 chars → error, missing sender open_id / unsupported channel → clear message, create failure → surfaced error
- `src/bridge/lark-channel.ts` — expose `LarkChannel.createChat` to the command layer
- `test/commands/index.test.ts` — happy path (creates group with name + invites sender + replies applink), usage, unsupported-channel, and failure cases
- `README.md` — command table entry + required scopes note

## Required app scopes

- `im:chat`
- `im:chat.members:write_only`

(apply in the Feishu developer console → 权限管理)

## Notes

- Group is created private / group mode; sender invited via open_id (from the message event).
- Reply includes an applink.feishu.cn deep link to open the chat.
- No session logic needed in the command: the new scope's session starts naturally when the user chats in the new group.
