### PR TITLE
fix(card): bound long streaming process cards

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -592,7 +592,9 @@ ACP `PromptResponse.usage` 提供该 ACP session 的累计 input/output/cache，
   reasoning、工具调用与结果位于 schema 2.0 `collapsible_panel`，运行时展开、结束后默认收起；
   detailed 含工具输入输出与 token usage。面板外的 notation 过程快照持续保留最新推理尾部、最近
   工具与结果；若平台拒绝 `collapsible_panel`，run-flow / guardian 会重试无该组件的 legacy 流式卡。
-  `config.summary` 另同步截断轨迹供消息预览使用；正常卡片正文不承载最终回答。
+  `config.summary` 另同步截断轨迹供消息预览使用；正常卡片正文不承载最终回答。相同 tool id 的
+  增量与完成事件归并为同一条记录；过程过长时以完整本地化卡片的 28,000 字符预算动态隐藏较早的
+  工具记录、保留最新记录，避免工具轨迹膨胀后被飞书以 `230099` 拒绝。
 - `src/card/run-state.ts`：`reduce(state, event)` 状态机；`usage` 字段由 `usage` 事件更新；
   `finalDeliveryError` 记录独立最终消息的发送失败并在过程卡显式展示。
 - `src/card/status-card.ts`：纯 `renderStatusCard(input)` / `statusCardMarkdown(input)`；展示

--- a/docs/conformance/claim.local.json
+++ b/docs/conformance/claim.local.json
@@ -3,7 +3,7 @@
   "subject": "io.github.plutokeating.dsh-lark-bot@0.16.0",
   "specVersion": "community-v0.15",
   "hostDescriptorDigest": "sha256:b440a6f6548c56d9b7e07627ddd3c5324fbdba5efca646eb010435d523d6b4a1",
-  "artifactDigest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+  "artifactDigest": "sha256:a9877505211351aabefdfe68aa616c89a4b9a9ef57c463b2cdab2430bf891cd3",
   "suiteVersion": "0.15.0-experimental+e1b902b0",
   "evidenceLevel": "Tested",
   "result": "pass",

--- a/docs/conformance/claim.remote.json
+++ b/docs/conformance/claim.remote.json
@@ -3,7 +3,7 @@
   "subject": "io.github.plutokeating.dsh-lark-bot@0.16.0",
   "specVersion": "community-v0.15",
   "hostDescriptorDigest": "sha256:993dd0fccfcd38c2d7bad2186ed725fa524a58f5572fe9df248d37d4319dbd47",
-  "artifactDigest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+  "artifactDigest": "sha256:a9877505211351aabefdfe68aa616c89a4b9a9ef57c463b2cdab2430bf891cd3",
   "suiteVersion": "0.15.0-experimental+e1b902b0",
   "evidenceLevel": "Tested",
   "result": "pass",

--- a/dsh-plugin.json
+++ b/dsh-plugin.json
@@ -30,7 +30,7 @@
     "repository": "https://github.com/PlutoKeating/dsh-lark-bot"
   },
   "artifact": {
-    "digest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+    "digest": "sha256:a9877505211351aabefdfe68aa616c89a4b9a9ef57c463b2cdab2430bf891cd3",
     "algorithm": "sha256",
     "path": "dist/plugin.js"
   },

--- a/src/card/run-renderer.ts
+++ b/src/card/run-renderer.ts
@@ -2,6 +2,11 @@ import type { FooterStatus, RunState, ToolEntry } from './run-state.js';
 import type { CardDensity } from './density.js';
 import { localizedCard, type CardLocale } from './i18n.js';
 
+// @larksuite/channel rolls over markdown at 30,000 characters to avoid
+// Feishu 230099. Trim tool history against a smaller full-card budget.
+const RUN_CARD_JSON_BUDGET = 28_000;
+const MAX_VISIBLE_TOOL_CALLS = 40;
+
 function markdown(content: string): object {
   return { tag: 'markdown', content };
 }
@@ -90,7 +95,13 @@ function hasAnswer(state: RunState): boolean {
   return state.blocks.some((block) => block.kind === 'text' && block.content.trim() !== '');
 }
 
-function processElements(state: RunState, detailed: boolean, compact: boolean, locale: CardLocale): object[] {
+function processElements(
+  state: RunState,
+  detailed: boolean,
+  compact: boolean,
+  locale: CardLocale,
+  maxTools: number,
+): object[] {
   const zh = locale === 'zh_cn';
   const elements: object[] = [];
   if (state.reasoning.content) {
@@ -100,8 +111,17 @@ function processElements(state: RunState, detailed: boolean, compact: boolean, l
       ),
     );
   }
-  for (const block of state.blocks) {
-    if (block.kind !== 'tool') continue;
+  const toolBlocks = state.blocks.filter((block) => block.kind === 'tool');
+  const visibleTools = maxTools === 0 ? [] : toolBlocks.slice(-maxTools);
+  const hiddenTools = toolBlocks.length - visibleTools.length;
+  if (hiddenTools > 0) {
+    elements.push(
+      noteMd(zh
+        ? `_已隐藏 ${hiddenTools} 个较早的工具调用，仅显示最新进展_`
+        : `_Hidden ${hiddenTools} older tool calls; showing the latest progress_`),
+    );
+  }
+  for (const block of visibleTools) {
     const tool = block.tool;
     if (compact) {
       elements.push(toolBlock(tool));
@@ -125,7 +145,13 @@ function processElements(state: RunState, detailed: boolean, compact: boolean, l
   return elements;
 }
 
-function thinkingPanel(state: RunState, detailed: boolean, compact: boolean, locale: CardLocale): object {
+function thinkingPanel(
+  state: RunState,
+  detailed: boolean,
+  compact: boolean,
+  locale: CardLocale,
+  maxTools: number,
+): object {
   return {
     tag: 'collapsible_panel',
     expanded: state.terminal === 'running',
@@ -136,7 +162,7 @@ function thinkingPanel(state: RunState, detailed: boolean, compact: boolean, loc
       icon_expanded_angle: -180,
     },
     border: { color: 'grey', corner_radius: '6px' },
-    elements: processElements(state, detailed, compact, locale),
+    elements: processElements(state, detailed, compact, locale, maxTools),
   };
 }
 
@@ -178,13 +204,18 @@ function ownerLine(state: RunState, locale: CardLocale): object | undefined {
   return state.scopeOwner ? noteMd(`👤 ${locale === 'zh_cn' ? '成员隔离会话' : 'Member-isolated session'}：${state.scopeOwner}`) : undefined;
 }
 
-function renderStandard(state: RunState, now: number, locale: CardLocale): object {
+function renderStandard(
+  state: RunState,
+  now: number,
+  locale: CardLocale,
+  maxTools: number,
+): object {
   const zh = locale === 'zh_cn';
   const elements: object[] = [];
   const owner = ownerLine(state, locale);
   if (owner) elements.push(owner);
 
-  elements.push(thinkingPanel(state, false, false, locale));
+  elements.push(thinkingPanel(state, false, false, locale, maxTools));
   elements.push(compatibilityProcessSnapshot(state, locale));
 
   if (state.terminal === 'interrupted') {
@@ -223,13 +254,18 @@ function renderStandard(state: RunState, now: number, locale: CardLocale): objec
   };
 }
 
-function renderCompact(state: RunState, now: number, locale: CardLocale): object {
+function renderCompact(
+  state: RunState,
+  now: number,
+  locale: CardLocale,
+  maxTools: number,
+): object {
   const zh = locale === 'zh_cn';
   const elements: object[] = [];
   const owner = ownerLine(state, locale);
   if (owner) elements.push(owner);
   elements.push(noteMd(summaryText(state, locale)));
-  elements.push(thinkingPanel(state, false, true, locale));
+  elements.push(thinkingPanel(state, false, true, locale, maxTools));
   elements.push(compatibilityProcessSnapshot(state, locale));
   if (state.finalDeliveryError) {
     elements.push(noteMd(`⚠️ ${zh ? '最终回答发送失败' : 'Final answer delivery failed'}：${state.finalDeliveryError}`));
@@ -253,13 +289,18 @@ function renderCompact(state: RunState, now: number, locale: CardLocale): object
   };
 }
 
-function renderDetailed(state: RunState, now: number, locale: CardLocale): object {
+function renderDetailed(
+  state: RunState,
+  now: number,
+  locale: CardLocale,
+  maxTools: number,
+): object {
   const zh = locale === 'zh_cn';
   const elements: object[] = [];
   const owner = ownerLine(state, locale);
   if (owner) elements.push(owner);
 
-  elements.push(thinkingPanel(state, true, false, locale));
+  elements.push(thinkingPanel(state, true, false, locale, maxTools));
   elements.push(compatibilityProcessSnapshot(state, locale));
 
   if (state.terminal === 'interrupted') {
@@ -309,12 +350,32 @@ export function renderCard(
   density: CardDensity = 'standard',
   now: number = Date.now(),
 ): object {
-  const render = (locale: CardLocale): object => {
-    if (density === 'compact') return renderCompact(state, now, locale);
-    if (density === 'detailed') return renderDetailed(state, now, locale);
-    return renderStandard(state, now, locale);
+  const render = (locale: CardLocale, maxTools: number): object => {
+    if (density === 'compact') return renderCompact(state, now, locale, maxTools);
+    if (density === 'detailed') return renderDetailed(state, now, locale, maxTools);
+    return renderStandard(state, now, locale, maxTools);
   };
-  return localizeRenderedCard(render('zh_cn'), render('en_us'));
+  const renderWithToolLimit = (maxTools: number): object =>
+    localizeRenderedCard(render('zh_cn', maxTools), render('en_us', maxTools));
+  const toolCount = state.blocks.filter((block) => block.kind === 'tool').length;
+  const initialLimit = Math.min(toolCount, MAX_VISIBLE_TOOL_CALLS);
+  const initialCard = renderWithToolLimit(initialLimit);
+  if (JSON.stringify(initialCard).length <= RUN_CARD_JSON_BUDGET) return initialCard;
+
+  let low = 0;
+  let high = initialLimit - 1;
+  let best = renderWithToolLimit(0);
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const candidate = renderWithToolLimit(middle);
+    if (JSON.stringify(candidate).length <= RUN_CARD_JSON_BUDGET) {
+      best = candidate;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return best;
 }
 
 /** Plain schema-2.0 card used when the native collapsible component is rejected. */

--- a/src/card/run-state.ts
+++ b/src/card/run-state.ts
@@ -122,24 +122,42 @@ export function reduce(state: RunState, event: AgentEvent): RunState {
         },
       };
 
-    case 'tool_use':
+    case 'tool_use': {
+      const blocks = closeStreamingText(state.blocks);
+      const existingIndex = blocks.findIndex(
+        (block) => block.kind === 'tool' && block.tool.id === event.id,
+      );
+      const nextBlocks = existingIndex === -1
+        ? [
+            ...blocks,
+            {
+              kind: 'tool' as const,
+              tool: {
+                id: event.id,
+                name: event.name,
+                input: event.input,
+                status: 'running' as const,
+              },
+            },
+          ]
+        : blocks.map((block, index) => {
+            if (index !== existingIndex || block.kind !== 'tool') return block;
+            return {
+              ...block,
+              tool: {
+                ...block.tool,
+                name: event.name,
+                input: event.input,
+              },
+            };
+          });
       return {
         ...state,
-        blocks: [
-          ...closeStreamingText(state.blocks),
-          {
-            kind: 'tool',
-            tool: {
-              id: event.id,
-              name: event.name,
-              input: event.input,
-              status: 'running',
-            },
-          },
-        ],
+        blocks: nextBlocks,
         reasoning: { ...state.reasoning, active: false },
         footer: 'tool_running',
       };
+    }
 
     case 'tool_result':
       return {

--- a/test/card/run-renderer.test.ts
+++ b/test/card/run-renderer.test.ts
@@ -91,4 +91,33 @@ describe('renderCard', () => {
     const snapshot = card.body.elements.find((element) => JSON.stringify(element).includes('过程快照'));
     expect(JSON.stringify(snapshot)).toContain('-LATEST');
   });
+
+  it.each(['compact', 'standard', 'detailed'] as const)(
+    'keeps long %s run cards within the streaming transport budget',
+    (density) => {
+      let state = initialState;
+      for (let index = 0; index < 80; index += 1) {
+        const marker = index === 0 ? 'OLDEST' : index === 79 ? 'LATEST' : `${index}`;
+        state = reduce(state, {
+          type: 'tool_use',
+          id: `tool-${index}`,
+          name: `tool-${marker}-${'n'.repeat(80)}`,
+          input: { query: `${marker}-${'i'.repeat(800)}` },
+        });
+        state = reduce(state, {
+          type: 'tool_result',
+          id: `tool-${index}`,
+          output: `${marker}-${'o'.repeat(800)}`,
+          isError: false,
+        });
+      }
+
+      const serialized = JSON.stringify(renderCard(state, density));
+      expect(serialized.length).toBeLessThanOrEqual(28_000);
+      expect(serialized).toContain('tool-LATEST');
+      expect(serialized).not.toContain('tool-OLDEST');
+      expect(serialized).toContain('较早的工具调用');
+      expect(serialized).toContain('older tool calls');
+    },
+  );
 });

--- a/test/card/run-state.test.ts
+++ b/test/card/run-state.test.ts
@@ -37,4 +37,44 @@ describe('run state reducer', () => {
       { kind: 'text', content: 'hello from dsh', streaming: false },
     ]);
   });
+
+  it('coalesces repeated updates for the same tool call', () => {
+    let state = reduce(initialState, {
+      type: 'tool_use',
+      id: 'tool-1',
+      name: 'read',
+      input: '',
+    });
+    state = reduce(state, {
+      type: 'tool_use',
+      id: 'tool-1',
+      name: 'read',
+      input: { path: 'src/index.ts' },
+    });
+    state = reduce(state, {
+      type: 'tool_result',
+      id: 'tool-1',
+      output: 'file contents',
+      isError: false,
+    });
+    state = reduce(state, {
+      type: 'tool_use',
+      id: 'tool-1',
+      name: 'read_file',
+      input: { path: 'src/index.ts' },
+    });
+
+    expect(state.blocks).toEqual([
+      {
+        kind: 'tool',
+        tool: {
+          id: 'tool-1',
+          name: 'read_file',
+          input: { path: 'src/index.ts' },
+          status: 'done',
+          output: 'file contents',
+        },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #74

## Summary

- coalesce repeated `tool_use` events by tool id instead of appending duplicate process blocks
- trim only older tool history when a localized run card approaches a 28,000-character transport budget
- preserve the newest tool calls and show a bilingual omission notice in compact, standard, and detailed modes

## Problem

Long native run cards could grow without a bound and Feishu rejected a later card patch with error `230099`. In the observed case, the same tool call could also be rendered twice because the SDK emits both a streaming tool-call delta and the committed tool call.

Before the fix, the regression fixture produced:

- compact: 33,216 serialized characters
- standard: 82,617 serialized characters
- detailed: 231,177 serialized characters
- one repeated tool id: three process blocks

## Root cause

`RunState.reduce()` appended every `tool_use` event even when the id already existed. `renderCard()` then rendered every stored tool block into both locale variants, so long tool-heavy runs kept increasing the full-card patch payload. The generic card stream sends that complete payload; unlike the channel package's markdown stream, it has no rollover for oversized content.

## Changes

- upsert repeated tool events while preserving an already-recorded result/status
- initially show at most 40 recent tool calls, then binary-search the largest recent subset that fits the 28,000-character full-card budget
- keep the full `RunState`; only the card presentation hides older entries
- document the behavior and refresh the verified plugin artifact digest/claims

The 28,000-character budget leaves headroom below `@larksuite/channel`'s 30,000-character streaming-content boundary.

## Validation

- `pnpm exec vitest run test/card/run-state.test.ts test/card/run-renderer.test.ts test/card/run-renderer-density.test.ts test/card/i18n.test.ts test/bridge/run-flow.test.ts` — 61 passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `pnpm check:tui-admission` — passed, including packed/installed artifact verification
- `pnpm check:publish-bundle` — passed
- `git diff --check` — passed

Local full-suite note: on macOS, normalizing `TMPDIR=/private/tmp` yields 633 passed, 4 skipped, and 2 unrelated failures (`doctor` npx-cache warning fixture and `supervise` timeout). Both failures are also reproducible on a clean `upstream/staging` worktree. `pnpm check:tui-tty` is Linux-specific today (`script -qec`) and fails with macOS `/usr/bin/script`; the repository CI runs on Ubuntu/Node 22.

## User-visible behavior

Short runs are unchanged. When a run has too much tool history for one card, users see the latest steps plus an explicit count of hidden older calls instead of losing the bridge process to a rejected patch.

