### PR TITLE
fix(plan): allow simple read-only shell inspections

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ guardian 仍只救援其配置的主实例。
 
 **关键任务计划门禁**：SDK / ACP / Web agent 在修改文件、运行脚本等较大或高风险动作前使用
 `lark_request_plan_approval`；同一 turn 未获批准时，runtime pre-execute 策略会拒绝写入、删除、
-移动、命令执行与 `run_code`。bridge 先把完整 Markdown 计划作为普通消息发出，再弹出“批准，开始执行 /
+移动、非只读 shell 命令与 `run_code`。`date`、`pwd`、`ls`、`rg`、`git status/log/diff` 等单条
+只读检查直接放行；包含串联、重定向、命令替换或未知程序的 shell 调用仍保守地走计划门禁。
+bridge 先把完整 Markdown 计划作为普通消息发出，再弹出“批准，开始执行 /
 继续规划”决策卡；卡内可填写修改意见。工具在等待期间阻塞且暂停空闲超时，批准后原任务自动继续；
 继续规划时 agent 会收到意见、修订计划并再次请求确认。门禁无固定十分钟截止，跟随所属 run 的取消
 信号；停止任务会精确取消该 session 的 pending 卡并撤回。legacy headless adapter 不具备工具回调能力。

--- a/README_EN.md
+++ b/README_EN.md
@@ -230,7 +230,9 @@ reject `web`, because a shared Web agent broadcast stream cannot isolate session
 
 **Plan gate for substantial tasks**: SDK / ACP / Web agents use `lark_request_plan_approval` before file
 changes, scripts, or other substantial/high-risk actions. A runtime pre-execute policy denies writes, deletes,
-moves, command execution and `run_code` in that turn until a plan is approved. The bridge sends the complete Markdown plan as a normal
+moves, non-read-only shell commands and `run_code` in that turn until a plan is approved. Single read-only
+inspections such as `date`, `pwd`, `ls`, `rg`, and `git status/log/diff` run directly; shell chaining,
+redirection, command substitution, and unknown executables remain behind the conservative plan gate. The bridge sends the complete Markdown plan as a normal
 message, then a card with **Approve and execute** / **Continue planning** plus optional feedback. The tool blocks
 and pauses the idle watchdog; approval resumes the original turn, while revision returns the feedback and requires
 another plan. There is no fixed ten-minute deadline: the gate follows the owning run's cancellation signal, and

--- a/docs/API.md
+++ b/docs/API.md
@@ -626,7 +626,9 @@ toast 在网络收尾前立即返回，发送与撤回则是独立的 best-effor
 只有 pending-card reply 免 @；topic scope 必须匹配 thread，member scope 必须匹配 sender open_id，拒绝路径不结算也不入队。
 
 `src/notify/plan-tool.ts` 注册 `lark_request_plan_approval` raw-schema dsh 工具，并通过
-`tools/pre-execute` 强制拒绝当前 turn 尚未批准的写入、删除、移动、命令执行与 `run_code`；通过 token 鉴权的
+`tools/pre-execute` 强制拒绝当前 turn 尚未批准的写入、删除、移动、非只读 shell 命令与 `run_code`。
+`bash` / `shell` 只有在命令不含换行、串联、管道、重定向、命令替换，且 executable 或 `git`
+subcommand 位于只读白名单时才绕过计划和逐工具审批；未知参数或语法一律保持高风险。通过 token 鉴权的
 `POST /plan` 回调，以 session id 反查 scope。`buildPlanHandler` 先发送完整 Markdown 计划，再注册并
 发送决策卡；返回 `{decision:'approved'|'revise', feedback?}` 后原 tool call 结束，agent 自动续跑。
 SDK / ACP managed runtime 与宿主 bundle 均装配 `./plan` export；等待期间与问答卡一样暂停 idle watchdog。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,7 +185,9 @@ TUI/WebUI 的 active session 不参与 binding 决策。
    计划工具通过同一 server 的 `/plan` 端点以 session 反查 immutable scope：完整计划先作为普通
    Markdown 消息发送，再由 `PlanApprovalRegistry` + schema 2.0 form card 等待 approve/revise 与
    可选 feedback；工具返回后原 agent turn 自动续跑，等待期间 idle watchdog 仅为所属 session 暂停。
-   `tools/pre-execute` 会拒绝当前 turn 尚未批准的 mutating/execute/`run_code` 调用；run 或 HTTP request
+   `tools/pre-execute` 会拒绝当前 turn 尚未批准的 mutating/execute/`run_code` 调用；`bash` / `shell`
+   仅对无控制符且命中明确命令/`git` 子命令白名单的单条只读检查放行，串联、重定向、命令替换、
+   未知程序与所有其他终端调用保持 fail closed。run 或 HTTP request
    取消时精确撤销并终态化该 session 的卡，因此 SDK、ACP、Web 宿主路径都不是仅靠提示词约束。
    默认 SDK 与 host bundle 还装配 `dsh-lark-bot/approval`：它先以 `tools/pre-execute` 强制拦截
    高风险工具，再以 structural listener 接入 rc.8

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -183,7 +183,9 @@ bot 会为每个飞书 scope 默认保存最近 40 条对话（`/retention` 可�
 
 **关键任务计划门禁**：SDK / ACP / Web agent 在较大或高风险动作前调用
 `lark_request_plan_approval`。完整计划先以普通 Markdown 消息发送，随后决策卡可“批准，开始执行”
-或填写意见后“继续规划”；未批准时 runtime 会拒绝写入、删除、移动、命令执行与 `run_code`，等待仅暂停
+或填写意见后“继续规划”；未批准时 runtime 会拒绝写入、删除、移动、非只读 shell 命令与 `run_code`。
+单条 `date`、`pwd`、`ls`、`rg`、`git status/log/diff` 等只读检查不需要计划审批；包含串联、重定向、
+命令替换或未知程序的 shell 调用仍按高风险处理。等待仅暂停
 该 session 的空闲超时，批准后原任务自动继续。停止任务会取消并撤回该 session 的卡；legacy headless 不支持工具回调。
 
 **逐操作审批**：默认 SDK 安装无需切换 adapter。计划获批后，dsh rc.8 对实际高风险工具调用会

--- a/docs/conformance/claim.local.json
+++ b/docs/conformance/claim.local.json
@@ -3,7 +3,7 @@
   "subject": "io.github.plutokeating.dsh-lark-bot@0.16.0",
   "specVersion": "community-v0.15",
   "hostDescriptorDigest": "sha256:b440a6f6548c56d9b7e07627ddd3c5324fbdba5efca646eb010435d523d6b4a1",
-  "artifactDigest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+  "artifactDigest": "sha256:0e926de54b76e2a51e2e0ba785027ea910b7cca87d5029eb98be8c4dce00e1a5",
   "suiteVersion": "0.15.0-experimental+e1b902b0",
   "evidenceLevel": "Tested",
   "result": "pass",

--- a/docs/conformance/claim.remote.json
+++ b/docs/conformance/claim.remote.json
@@ -3,7 +3,7 @@
   "subject": "io.github.plutokeating.dsh-lark-bot@0.16.0",
   "specVersion": "community-v0.15",
   "hostDescriptorDigest": "sha256:993dd0fccfcd38c2d7bad2186ed725fa524a58f5572fe9df248d37d4319dbd47",
-  "artifactDigest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+  "artifactDigest": "sha256:0e926de54b76e2a51e2e0ba785027ea910b7cca87d5029eb98be8c4dce00e1a5",
   "suiteVersion": "0.15.0-experimental+e1b902b0",
   "evidenceLevel": "Tested",
   "result": "pass",

--- a/dsh-plugin.json
+++ b/dsh-plugin.json
@@ -30,7 +30,7 @@
     "repository": "https://github.com/PlutoKeating/dsh-lark-bot"
   },
   "artifact": {
-    "digest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+    "digest": "sha256:0e926de54b76e2a51e2e0ba785027ea910b7cca87d5029eb98be8c4dce00e1a5",
     "algorithm": "sha256",
     "path": "dist/plugin.js"
   },

--- a/src/adapters/dsh/acp-runtime.ts
+++ b/src/adapters/dsh/acp-runtime.ts
@@ -5,6 +5,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { DSH_COMPATIBILITY } from '../../config/dsh-compat.js';
 import { discoverDshBin, resolveDshHome } from '../../config/dsh-runtime.js';
+import { BRIDGE_RUNTIME_PERSONA } from './bridge-persona.js';
 import type { OwnPackageInfo } from './own-package.js';
 import { ownPackageInfo } from './own-package.js';
 import { profilePackageMatches } from './profile-package.js';
@@ -75,15 +76,15 @@ export function acpPatchYaml(provider: string, model: string): string {
     `        provider: ${provider}`,
     `        model: ${model}`,
     '',
-    '# Unattended IM runtime: interactive user questions cannot be answered',
-    '# through Feishu, so the tool is disabled (default-deny).',
+    '# Host-native interactive questions are disabled because this IM runtime',
+    '# uses lark_ask_user for interactive answers through Feishu/Lark.',
     '- id: user-questions',
     '  disabled: true',
     '',
     '- id: system-prompt',
     '  config:',
     '    persona: >-',
-    '      You are a coding agent powered by the {{model}} model. Your working directory is {{cwd}}. Before substantial or high-risk repository actions, use lark_request_plan_approval and wait for approval.',
+    `      ${BRIDGE_RUNTIME_PERSONA}`,
     '',
     '- id: hmr',
     '  disabled: true',

--- a/src/adapters/dsh/bridge-persona.ts
+++ b/src/adapters/dsh/bridge-persona.ts
@@ -1,0 +1,8 @@
+export const BRIDGE_RUNTIME_PERSONA = [
+  'You are a coding agent powered by the {{model}} model.',
+  'Your working directory is {{cwd}}.',
+  'Read-only inspections with simple shell commands do not need plan approval; run them directly without chaining, redirects, or command substitution.',
+  'Before modifying files, installing packages, running scripts, pushing, deleting, or taking another substantial or high-risk action, use lark_request_plan_approval and wait for approval.',
+  'If you need a decision or missing information from the user, use lark_ask_user and wait for the answer.',
+  'Do not invent a sandbox, policy, or permission restriction; if a tool fails, report its actual error.',
+].join(' ');

--- a/src/adapters/dsh/sdk-runtime.ts
+++ b/src/adapters/dsh/sdk-runtime.ts
@@ -5,6 +5,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { DSH_COMPATIBILITY } from '../../config/dsh-compat.js';
 import { discoverDshBin, resolveDshHome } from '../../config/dsh-runtime.js';
+import { BRIDGE_RUNTIME_PERSONA } from './bridge-persona.js';
 import type { OwnPackageInfo } from './own-package.js';
 import { ownPackageInfo } from './own-package.js';
 import { profilePackageMatches } from './profile-package.js';
@@ -89,8 +90,8 @@ export function patchYamlFor(options?: { bridgeTools?: boolean }): string {
     '      config:',
     '        maxTokensAsSuccess: true',
     '',
-    '# Unattended IM runtime: interactive user questions cannot be answered',
-    '# through Feishu, so the tool is disabled (default-deny).',
+    '# Host-native interactive questions are disabled because this IM runtime',
+    '# uses lark_ask_user for interactive answers through Feishu/Lark.',
     '- id: user-questions',
     '  disabled: true',
     '',
@@ -98,7 +99,7 @@ export function patchYamlFor(options?: { bridgeTools?: boolean }): string {
     '  config:',
     '    persona: >-',
     bridgeTools
-      ? '      You are a coding agent powered by the {{model}} model. Your working directory is {{cwd}}. Before substantial or high-risk repository actions, use lark_request_plan_approval and wait for approval.'
+      ? `      ${BRIDGE_RUNTIME_PERSONA}`
       : '      You are a coding agent powered by the {{model}} model. Your working directory is {{cwd}}.',
     '',
     '- id: hmr',

--- a/src/notify/plan-tool.ts
+++ b/src/notify/plan-tool.ts
@@ -20,6 +20,43 @@ export interface PlanPolicyExecution {
   agent?: object;
 }
 
+const READ_ONLY_SHELL_TOOLS = new Set(['bash', 'shell']);
+const READ_ONLY_COMMANDS = new Set([
+  'basename',
+  'cat',
+  'date',
+  'df',
+  'dirname',
+  'du',
+  'grep',
+  'head',
+  'id',
+  'jq',
+  'ls',
+  'pgrep',
+  'ps',
+  'pwd',
+  'readlink',
+  'realpath',
+  'rg',
+  'stat',
+  'tail',
+  'uname',
+  'wc',
+  'whoami',
+]);
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
+  'diff',
+  'ls-files',
+  'ls-tree',
+  'log',
+  'merge-base',
+  'rev-parse',
+  'show',
+  'status',
+]);
+const SHELL_CONTROL_SYNTAX = /[\n\r;&|<>`]|\$\(|\$\{/u;
+
 type PlanPolicyContext = ToolPluginContext & {
   on(
     event: 'agent/pre-step',
@@ -141,6 +178,10 @@ export function apply(ctx: Context, config: Config = {}) {
 export function isHighRiskTool(ctx: ToolPluginContext, execution: PlanPolicyExecution): boolean {
   if (execution.name === 'lark_request_plan_approval') return false;
   if (execution.name === 'run_code') return true;
+  const normalized = execution.name.toLowerCase().replaceAll('-', '_');
+  if (READ_ONLY_SHELL_TOOLS.has(normalized)) {
+    return !isSimpleReadOnlyShellCommand(execution.arguments);
+  }
   try {
     const view = ctx.tools.get?.(execution.name, execution.agent)?.presentCall?.(
       execution.arguments,
@@ -151,7 +192,84 @@ export function isHighRiskTool(ctx: ToolPluginContext, execution: PlanPolicyExec
   } catch {
     // Fall through to the conservative name classifier.
   }
-  const normalized = execution.name.toLowerCase().replaceAll('-', '_');
   return /(^|_)(bash|shell|exec|execute|run|write|edit|patch|delete|remove|move|rename)(_|$)/u
     .test(normalized);
+}
+
+/**
+ * Read-only shell calls bypass both the plan gate and one-shot approval.
+ * Keep this deliberately narrow: one command only, no shell composition, and
+ * an allowlisted executable/subcommand. Unknown syntax remains high risk.
+ */
+function isSimpleReadOnlyShellCommand(rawArguments: unknown): boolean {
+  const command = shellCommand(rawArguments)?.trim();
+  if (!command || SHELL_CONTROL_SYNTAX.test(command)) return false;
+  const words = command.split(/\s+/u);
+  const executablePath = words[0];
+  if (
+    !executablePath ||
+    (executablePath.includes('/') &&
+      !executablePath.startsWith('/bin/') &&
+      !executablePath.startsWith('/usr/bin/'))
+  ) return false;
+  const executable = executablePath.split('/').at(-1);
+  if (!executable) return false;
+  if (executable === 'git') return isReadOnlyGitCommand(words.slice(1));
+  if (!READ_ONLY_COMMANDS.has(executable)) return false;
+  if (executable === 'date') {
+    return words.slice(1).every((word) =>
+      word === '-u' || word === '--utc' || word === '--universal' || word.startsWith('+')
+    );
+  }
+  if (executable === 'rg') {
+    return !words.slice(1).some((word) =>
+      word === '--pre' ||
+      word.startsWith('--pre=') ||
+      word === '--hostname-bin' ||
+      word.startsWith('--hostname-bin=')
+    );
+  }
+  return true;
+}
+
+function shellCommand(rawArguments: unknown): string | undefined {
+  if (typeof rawArguments === 'object' && rawArguments !== null && !Array.isArray(rawArguments)) {
+    const command = (rawArguments as { command?: unknown }).command;
+    return typeof command === 'string' ? command : undefined;
+  }
+  if (typeof rawArguments !== 'string') return undefined;
+  try {
+    return shellCommand(JSON.parse(rawArguments));
+  } catch {
+    return rawArguments;
+  }
+}
+
+function isReadOnlyGitCommand(words: readonly string[]): boolean {
+  let index = 0;
+  while (words[index] === '-C') {
+    if (!words[index + 1]) return false;
+    index += 2;
+  }
+  const subcommand = words[index];
+  if (subcommand === 'branch') {
+    const flags = words.slice(index + 1);
+    return flags.length === 0 || flags.every((word) =>
+      ['--show-current', '--list', '--all', '-a', '--remotes', '-r', '-v', '-vv'].includes(word)
+    );
+  }
+  if (subcommand === 'remote') {
+    const args = words.slice(index + 1);
+    return args.length === 0 ||
+      args.every((word) => word === '-v' || word === '--verbose') ||
+      args[0] === 'get-url';
+  }
+  if (!subcommand || !READ_ONLY_GIT_SUBCOMMANDS.has(subcommand)) return false;
+  return !words.slice(index + 1).some((word) =>
+    word === '-o' ||
+    word === '--output' ||
+    word.startsWith('--output=') ||
+    word === '--ext-diff' ||
+    word === '--textconv'
+  );
 }

--- a/test/adapters/dsh/acp-runtime.test.ts
+++ b/test/adapters/dsh/acp-runtime.test.ts
@@ -47,6 +47,10 @@ describe('resolveAcpLaunch', () => {
     expect(patch).toContain("name: 'dsh-lark-bot/plan'");
     expect(patch).not.toContain('id: lark-approval-answerer');
     expect(patch).toContain('use lark_request_plan_approval');
+    expect(patch).toContain('Read-only inspections with simple shell commands do not need plan approval');
+    expect(patch).toContain('use lark_ask_user and wait for the answer');
+    expect(patch).toContain('Do not invent a sandbox, policy, or permission restriction');
+    expect(patch).toContain('uses lark_ask_user for interactive answers');
   });
 
   it('resolves the discovered bin with the ACP profile', () => {

--- a/test/adapters/dsh/sdk-runtime.test.ts
+++ b/test/adapters/dsh/sdk-runtime.test.ts
@@ -34,6 +34,10 @@ describe('resolveSdkLaunch', () => {
     expect(patch).toContain("id: lark-approval-answerer");
     expect(patch).toContain("name: 'dsh-lark-bot/approval'");
     expect(patch).toContain('use lark_request_plan_approval');
+    expect(patch).toContain('Read-only inspections with simple shell commands do not need plan approval');
+    expect(patch).toContain('use lark_ask_user and wait for the answer');
+    expect(patch).toContain('Do not invent a sandbox, policy, or permission restriction');
+    expect(patch).toContain('uses lark_ask_user for interactive answers');
   });
 
   it('omits the bridge tools from the core-only safe SDK overlay', () => {

--- a/test/notify/approval-answerer.test.ts
+++ b/test/notify/approval-answerer.test.ts
@@ -90,6 +90,27 @@ describe('lark approval answerer', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('bypasses one-shot approval for simple read-only shell inspections', async () => {
+    let preExecute: ((execution: unknown, next: () => Promise<unknown>) => Promise<unknown>) | undefined;
+    const on = (event: string, listener: unknown): void => {
+      if (event === 'tools/pre-execute') preExecute = listener as typeof preExecute;
+    };
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as never;
+    apply({
+      on,
+      tools: { get: () => ({ presentCall: () => ({ card: 'terminal' }) }) },
+    } as never, { endpoint: 'http://127.0.0.1/approval', token: 't' });
+    const next = vi.fn(async () => ({ kind: 'allow' }));
+
+    await expect(preExecute?.({
+      name: 'bash', arguments: { command: 'git status --short' },
+      agent: { session: { id: 's' } },
+    }, next)).resolves.toEqual({ kind: 'allow' });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('allows exactly the approved execution and reuses it for a nested official request', async () => {
     let preExecute: ((execution: unknown, next: () => Promise<unknown>) => Promise<unknown>) | undefined;
     let approval: ((request: unknown, next: () => Promise<string>) => Promise<string>) | undefined;

--- a/test/notify/plan-tool.test.ts
+++ b/test/notify/plan-tool.test.ts
@@ -97,4 +97,79 @@ describe('lark_request_plan_approval tool', () => {
     await preStep({ agent, turn: 2 }, allow);
     await expect(preExecute(edit, allow)).resolves.toMatchObject({ kind: 'deny' });
   });
+
+  it('allows simple read-only shell inspections without plan approval', async () => {
+    let preExecute: (
+      execution: { name: string; arguments: unknown; agent?: object },
+      next: () => Promise<unknown>,
+    ) => Promise<unknown> = async (_execution, next) => next();
+    const on = (event: string, listener: unknown): void => {
+      if (event === 'tools/pre-execute') preExecute = listener as typeof preExecute;
+    };
+    apply({
+      on,
+      tools: {
+        register: vi.fn(),
+        get: () => ({ presentCall: () => ({ card: 'terminal' }) }),
+      },
+    } as never);
+    const next = vi.fn(async () => ({ kind: 'allow' }));
+
+    for (const command of [
+      'date',
+      '/usr/bin/date +%F',
+      'pwd',
+      'ls -la /tmp',
+      'rg --files src',
+      'git status --short',
+      'git log -5 --oneline',
+      'git diff --check',
+      'git branch --show-current',
+      'git remote -v',
+      'ps aux',
+    ]) {
+      await expect(preExecute({ name: 'bash', arguments: { command } }, next)).resolves.toEqual({
+        kind: 'allow',
+      });
+    }
+    expect(next).toHaveBeenCalledTimes(11);
+  });
+
+  it('keeps mutating, compound, redirected, and unknown shell commands behind the plan gate', async () => {
+    let preExecute: (
+      execution: { name: string; arguments: unknown; agent?: object },
+      next: () => Promise<unknown>,
+    ) => Promise<unknown> = async (_execution, next) => next();
+    const on = (event: string, listener: unknown): void => {
+      if (event === 'tools/pre-execute') preExecute = listener as typeof preExecute;
+    };
+    apply({
+      on,
+      tools: {
+        register: vi.fn(),
+        get: () => ({ presentCall: () => ({ card: 'terminal' }) }),
+      },
+    } as never);
+    const next = vi.fn(async () => ({ kind: 'allow' }));
+
+    for (const command of [
+      'rm -rf build',
+      'git push fork HEAD',
+      'date; rm file',
+      'pwd > location.txt',
+      'echo $(rm file)',
+      'node script.mjs',
+      'date --set=tomorrow',
+      'rg --pre=./transform pattern',
+      'git diff --output=changes.patch',
+      'git branch new-branch',
+      'git remote set-url origin example.invalid/repo',
+      './date',
+    ]) {
+      await expect(preExecute({ name: 'bash', arguments: { command } }, next)).resolves.toMatchObject({
+        kind: 'deny',
+      });
+    }
+    expect(next).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #59

## Why

The plan policy treated every `bash` call as high risk before looking at its arguments. The terminal presentation and the tool-name fallback therefore blocked `date`, `pwd`, `rg`, and read-only Git inspection in exactly the same way as a mutating command.

## What users will see

One simple read-only shell command can run without a plan or one-shot approval. Shell chaining, pipes, redirects, command substitution, unknown executables, scripts, writes, and mutating Git commands remain behind the existing gates.

The managed SDK and ACP personas now also point agents to `lark_ask_user` for missing decisions and tell them to report real tool errors instead of inventing a sandbox explanation.

## Surface area

- Default behavior change: strict read-only fast path for `bash` / `shell`.
- No new dependency, command, environment variable, or persisted state.

## Verification

### Bug fix (red to green)

The targeted suite had four failures on `upstream/staging`: read-only `bash` was denied by both policy consumers, and the SDK/ACP overlays lacked the required guidance. The same command is green on this branch:

- `pnpm exec vitest run test/notify/plan-tool.test.ts test/notify/approval-answerer.test.ts test/adapters/dsh/sdk-runtime.test.ts test/adapters/dsh/acp-runtime.test.ts` — 28 passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `pnpm check:publish-bundle` — passed
- `pnpm check:tui-admission` — passed, including packed/installed artifact verification
- `git diff --check` — passed

`pnpm test` completed with 633 passed and 4 skipped; the only failure is the existing macOS `doctor` npx-cache warning fixture. This PR does not modify that test or its implementation. `pnpm check:tui-tty` remains Linux-only because macOS `/usr/bin/script` does not support `-c`.

## Safety boundary

The fast path rejects shell control syntax and only accepts an explicit executable/subcommand allowlist. It also rejects `date --set`, ripgrep preprocessors, Git output files, branch creation, remote mutation, and untrusted executable paths.

## Related

- #18 introduced the plan gate.
- #58 is an orthogonal streaming-card size fix.
