### PR TITLE
fix(paths): canonicalize macOS aliases

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -642,7 +642,8 @@ agent 错误不会发送不完整的最终回答。
 `src/config/security.ts` 提供：
 
 - `redactSecrets(text)`：Bearer / `sk-` / `api_key=` 正则脱敏。
-- `isPathWithin(root, candidate)`：realpath containment（拒绝符号链接逃逸）。
+- `isPathWithin(root, candidate)`：从最深已存在祖先开始做 realpath containment；因此可接受同一目录
+  的平台路径别名和未创建后代，同时拒绝已存在或未存在目标下的符号链接逃逸。
 - `truncateUtf8Safe(text, maxBytes)`：UTF-8 安全字节截断。
 - `isEventFresh(timestampMs, windowMs, now?)`：过期事件拒绝。
 - `isSafeHttpUrl(url)`：SSRF 防护（拒绝环回 / 私网 / 链路本地 / CGNAT / IPv6 ULA）。

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -184,7 +184,8 @@
 - SDK / ACP / Web agent 自动获得 `lark_send_file(path, file_name?)`；目标由当前 native session
   固定为原 chat/thread，不允许模型指定其他会话。
 - bridge 只读取当前 workspace、当前 scope 的实际执行 worktree、当前 scope 归档和实例日志中的
-  realpath 普通文件；runtime cwd 仅解析相对路径，不能扩大允许根。拒绝 symlink 越界、目录、不安全
+  realpath 普通文件；runtime cwd 仅解析相对路径，不能扩大允许根。路径包含检查必须统一平台路径
+  别名，并从最深已存在祖先解析尚未创建的后代。拒绝 symlink 越界、目录、不安全
   文件名与默认超过 20 MiB 的文件，失败作为结构化工具结果返回。
 - 回调沿用 127.0.0.1 + 每启动随机 token；文件内容不进入 JSON 请求，bridge 校验后直接通过
   channel 二进制上传能力发送。

--- a/docs/conformance/claim.local.json
+++ b/docs/conformance/claim.local.json
@@ -3,7 +3,7 @@
   "subject": "io.github.plutokeating.dsh-lark-bot@0.16.0",
   "specVersion": "community-v0.15",
   "hostDescriptorDigest": "sha256:b440a6f6548c56d9b7e07627ddd3c5324fbdba5efca646eb010435d523d6b4a1",
-  "artifactDigest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+  "artifactDigest": "sha256:fd48f2300cc7beed1e5c34eb179e2728340983947496c55c9ff95f4858324d95",
   "suiteVersion": "0.15.0-experimental+e1b902b0",
   "evidenceLevel": "Tested",
   "result": "pass",

--- a/docs/conformance/claim.remote.json
+++ b/docs/conformance/claim.remote.json
@@ -3,7 +3,7 @@
   "subject": "io.github.plutokeating.dsh-lark-bot@0.16.0",
   "specVersion": "community-v0.15",
   "hostDescriptorDigest": "sha256:993dd0fccfcd38c2d7bad2186ed725fa524a58f5572fe9df248d37d4319dbd47",
-  "artifactDigest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+  "artifactDigest": "sha256:fd48f2300cc7beed1e5c34eb179e2728340983947496c55c9ff95f4858324d95",
   "suiteVersion": "0.15.0-experimental+e1b902b0",
   "evidenceLevel": "Tested",
   "result": "pass",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -139,6 +139,9 @@
 - **dsh Web 可视化设置 done（issue #36）**：Host 注册实际 profile-backed settings namespace，
   包内 `./client` 在官方 Plugins 配置页渲染应用、workspace、模型、并行数、adapter 与提醒；
   App Secret write-only，保存串行 reload，诊断快捷入口和命令/env 降级齐备。
+- **macOS 路径别名修复（issue #69）**：containment 与 CLI 自执行检测同时规范化 `/var` 一类
+  平台别名；未创建后代从最深已存在祖先继续解析，仍拒绝 symlink 越界。doctor 缓存路径测试按
+  当前平台写入服务入口，默认 macOS `TMPDIR` 下可完整运行测试。
 
 Milestones (English): P1 — scan-to-bind and a streaming card round-trip; P2 — named workspaces with
 isolated git worktrees and per-project AGENTS.md injection, native SDK session continuation;

--- a/dsh-plugin.json
+++ b/dsh-plugin.json
@@ -30,7 +30,7 @@
     "repository": "https://github.com/PlutoKeating/dsh-lark-bot"
   },
   "artifact": {
-    "digest": "sha256:03a0110d40bd000ef96b1988a4728363c76e90d9e6b45b79ebef5895ae3e260e",
+    "digest": "sha256:fd48f2300cc7beed1e5c34eb179e2728340983947496c55c9ff95f4858324d95",
     "algorithm": "sha256",
     "path": "dist/plugin.js"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -243,7 +243,7 @@ export function isDirectInvocation(
 ): boolean {
   if (!entry) return false;
   try {
-    return realpathSync(entry) === fileURLToPath(metaUrl);
+    return realpathSync(entry) === realpathSync(fileURLToPath(metaUrl));
   } catch {
     return false;
   }

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -1,6 +1,6 @@
-import { realpathSync } from 'node:fs';
+import { lstatSync, realpathSync } from 'node:fs';
 import { isIP } from 'node:net';
-import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 
 const REDACTED = '[redacted]';
 
@@ -21,11 +21,30 @@ export function redactSecrets(text: string): string {
   return result;
 }
 
-function resolveReal(path: string): string {
-  try {
-    return realpathSync(path);
-  } catch {
-    return resolve(path);
+function resolveReal(path: string): string | undefined {
+  let cursor = resolve(path);
+  const missingParts: string[] = [];
+
+  while (true) {
+    try {
+      return resolve(realpathSync(cursor), ...missingParts.reverse());
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return undefined;
+
+      // A broken symlink also reports ENOENT from realpath. Fail closed instead
+      // of treating the symlink name as an ordinary missing path segment.
+      try {
+        lstatSync(cursor);
+        return undefined;
+      } catch (lstatError) {
+        if ((lstatError as NodeJS.ErrnoException).code !== 'ENOENT') return undefined;
+      }
+
+      const parent = dirname(cursor);
+      if (parent === cursor) return undefined;
+      missingParts.push(basename(cursor));
+      cursor = parent;
+    }
   }
 }
 
@@ -36,6 +55,7 @@ function resolveReal(path: string): string {
 export function isPathWithin(root: string, candidate: string): boolean {
   const rootReal = resolveReal(root);
   const candidateReal = resolveReal(candidate);
+  if (rootReal === undefined || candidateReal === undefined) return false;
   const rel = relative(rootReal, candidateReal);
   return (
     rel === '' ||

--- a/test/cli/commands/doctor.test.ts
+++ b/test/cli/commands/doctor.test.ts
@@ -1,10 +1,11 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { runDoctor } from '../../../src/cli/commands/doctor.js';
 import { ConfigStore } from '../../../src/config/profile-store.js';
 import { ScopeDirectory } from '../../../src/bridge/scope-directory.js';
+import { guardianServiceFilePath } from '../../../src/guardian/install.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -109,31 +110,34 @@ describe('runDoctor', () => {
     expect(probe).not.toHaveBeenCalled();
   });
 
-  it('warns when the guardian unit points into the npm cache', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'dsh-lark-doctor-guardian-'));
-    process.env.DSH_LARK_HOME = root;
-    process.env.DSH_LARK_DSH_COMMAND = 'node';
-    process.env.DSH_LARK_ADAPTER = 'headless';
-    process.env.DSH_LARK_UPGRADE_CHECK = '0';
-    const unitDir = join(root, '.config', 'systemd', 'user');
-    await mkdir(unitDir, { recursive: true });
-    await writeFile(
-      join(unitDir, 'dsh-lark-guardian.service'),
-      'ExecStart=/usr/bin/node /home/u/.npm/_npx/abc/node_modules/dsh-lark-bot/dist/cli.js guardian run\n',
-      'utf8',
-    );
-    const outputChunks: string[] = [];
-    try {
-      await runDoctor({
-        version: '0.13.1',
-        output: (text) => outputChunks.push(text),
-        guardianRoot: root,
-      });
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-    expect(outputChunks.join('')).toContain('guardian: ⚠️ 服务单元指向 npx 缓存路径');
-  });
+  it.skipIf(process.platform !== 'linux' && process.platform !== 'darwin')(
+    'warns when the guardian unit points into the npm cache',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'dsh-lark-doctor-guardian-'));
+      process.env.DSH_LARK_HOME = root;
+      process.env.DSH_LARK_DSH_COMMAND = 'node';
+      process.env.DSH_LARK_ADAPTER = 'headless';
+      process.env.DSH_LARK_UPGRADE_CHECK = '0';
+      const unitPath = guardianServiceFilePath(process.platform, root);
+      await mkdir(dirname(unitPath), { recursive: true });
+      await writeFile(
+        unitPath,
+        'ExecStart=/usr/bin/node /home/u/.npm/_npx/abc/node_modules/dsh-lark-bot/dist/cli.js guardian run\n',
+        'utf8',
+      );
+      const outputChunks: string[] = [];
+      try {
+        await runDoctor({
+          version: '0.13.1',
+          output: (text) => outputChunks.push(text),
+          guardianRoot: root,
+        });
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+      expect(outputChunks.join('')).toContain('guardian: ⚠️ 服务单元指向 npx 缓存路径');
+    },
+  );
 
   it('surfaces a pending restart after an upgrade', async () => {
     const root = await mkdtemp(join(tmpdir(), 'dsh-lark-doctor-restart-'));

--- a/test/config/security.test.ts
+++ b/test/config/security.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -43,15 +43,25 @@ describe('isPathWithin', () => {
     expect(isPathWithin(root, join(root, '..', 'outside'))).toBe(false);
   });
 
+  it('accepts a missing descendant through an alias of the same root', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'dsh-sec-alias-'));
+    tempDirs.push(parent);
+    const root = join(parent, 'root');
+    const alias = join(parent, 'root-alias');
+    await mkdir(root);
+    await symlink(root, alias, process.platform === 'win32' ? 'junction' : 'dir');
+    expect(isPathWithin(root, join(alias, 'a', 'b'))).toBe(true);
+  });
+
   it('rejects symlink escapes when the target exists', async () => {
     const root = await mkdtemp(join(tmpdir(), 'dsh-sec-link-'));
     const outside = await mkdtemp(join(tmpdir(), 'dsh-sec-out-'));
     tempDirs.push(root, outside);
     await writeFile(join(outside, 'secret.txt'), 'secret');
     const link = join(root, 'escape');
-    const { symlink } = await import('node:fs/promises');
     await symlink(outside, link);
     expect(isPathWithin(root, join(link, 'secret.txt'))).toBe(false);
+    expect(isPathWithin(root, join(link, 'missing.txt'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- canonicalize missing descendants through their deepest existing ancestor
- keep containment fail-closed for broken symlinks and other realpath errors
- compare canonical entry and module paths for direct CLI invocation
- make the doctor npm-cache fixture use the current supported service-entry path

Closes #69

## Validation

- affected tests: 25 passed
- full default macOS suite: 632 passed, 4 skipped
- typecheck: passed
- build: passed
- publish-bundle check: passed
- TUI admission check: passed