### PR TITLE
fix(ci): support BSD script for PTY checks

### DIFF
--- a/docs/conformance/README.md
+++ b/docs/conformance/README.md
@@ -8,8 +8,9 @@ TUI Admission revision `e1b902b0f95f4280a8e68d414ec7a4d25d6ce106` and its vendor
 - `claim.*.json` binds each descriptor digest to the exact built `dist/plugin.js` digest.
 - `pnpm check:tui-admission` validates the unique manifest, all lockfile package integrities, then performs a
   real `npm pack` + clean temporary consumer install and re-hashes the installed host facet.
-- `pnpm check:tui-tty` allocates a real PTY and loads the published `dist/plugin.js` inside it. Windows fails
-  closed until equivalent external ConPTY evidence is supplied.
+- `pnpm check:tui-tty` allocates a real PTY and loads the published `dist/plugin.js` inside it, using the
+  util-linux `script` form on Linux and the positional BSD form on macOS. Windows fails closed until equivalent
+  external ConPTY evidence is supplied.
 - `test/tui/*.test.ts` covers all five decisions, local/remote/container profiles, repeated activation,
   optional-seam absence/failure and deterministic cleanup. The plugin never caches or consumes a Presentation.
 

--- a/scripts/check-tui-tty.mjs
+++ b/scripts/check-tui-tty.mjs
@@ -16,8 +16,14 @@ if (process.platform === 'win32') {
 }
 
 const self = fileURLToPath(import.meta.url);
-const command = `${shellQuote(process.execPath)} ${shellQuote(self)} --child`;
-const result = spawnSync('/usr/bin/script', ['-qec', command, '/dev/null'], {
+const scriptArgs = process.platform === 'darwin'
+  ? ['-q', '-e', '/dev/null', process.execPath, self, '--child']
+  : [
+      '-qec',
+      `${shellQuote(process.execPath)} ${shellQuote(self)} --child`,
+      '/dev/null',
+    ];
+const result = spawnSync('/usr/bin/script', scriptArgs, {
   encoding: 'utf8',
   stdio: ['ignore', 'pipe', 'pipe'],
 });


### PR DESCRIPTION
## Summary

- keep the util-linux script invocation on Linux
- use the positional BSD script command form on macOS
- preserve the real stdout.isTTY and built-plugin load assertions
- keep Windows fail-closed pending external ConPTY evidence

Closes #71

## Validation

- check:tui-tty on macOS: passed with a real PTY
- typecheck: passed
- build: passed